### PR TITLE
Not use TooManyStatements and UncommunicativeVariableName check

### DIFF
--- a/config.reek
+++ b/config.reek
@@ -9,7 +9,11 @@ TooManyStatements:
   enabled: true
   exclude:
   - initialize
-  - change
-  - up
-  - down
   max_statements: 5
+
+"db/migrate":
+  TooManyStatements:
+    enabled: false
+
+  UncommunicativeVariableName:
+    enabled: false


### PR DESCRIPTION
for migrations