### PR TITLE
Disable UtilityFunction smell for workers

### DIFF
--- a/config.reek
+++ b/config.reek
@@ -16,3 +16,7 @@ TooManyStatements:
   - up
   - down
   max_statements: 5
+
+"app/workers":
+  UtilityFunction:
+    enabled: false


### PR DESCRIPTION
Sooo

Since all `perform` methods will be treated as "UtilityFunction"s it may be logical to disable it